### PR TITLE
Update sources.json to fix Boxnovel

### DIFF
--- a/scripts/multisrc/madara/sources.json
+++ b/scripts/multisrc/madara/sources.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "boxnovel",
-    "sourceSite": "https://boxnovel.com/",
+    "sourceSite": "https://novgo.co/",
     "sourceName": "BoxNovel",
     "options": {
       "useNewChapterEndpoint": true,


### PR DESCRIPTION
The boxnovel.com domain now points towards novgo.com as such, I have changed the URL from boxnovel.com to to novgo in order to fix the issue. I have not made new plugin source as Dartford mean that people will have to migrate all the novels from Box novel to novgo.